### PR TITLE
Fix: Remove duplicate app.listen in backend server

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -515,8 +515,3 @@ app.get('/api/notes/:noteName', async (req, res) => {
         res.status(500).json({ error: `Failed to read note: ${noteName}` });
     }
 });
-
-
-app.listen(PORT, () => {
-    console.log(`Server listening on port ${PORT}`);
-});


### PR DESCRIPTION
A duplicate `app.listen(PORT, ...)` call was present in `backend/server.js`, which would cause an EADDRINUSE error and server instability. This instability likely led to Express's default HTML error pages being served instead of JSON responses from API routes, causing 'Unexpected token <' errors on the frontend.

Removing the redundant call allows the server to start correctly, ensuring API routes are properly handled and return their intended JSON responses.