### PR TITLE
Fix: Correct missing parenthesis in searchInput event listener

### DIFF
--- a/frontend/script.js
+++ b/frontend/script.js
@@ -614,7 +614,7 @@ document.addEventListener('DOMContentLoaded', () => {
             searchResultsList.innerHTML = '';
             searchResultsContainer.style.display = 'block';
         }
-    } // End of renderSearchResults function
+    }); // Added missing parenthesis for addEventListener
 
     // Event listener for the sort dropdown
     searchSortSelect.addEventListener('change', () => {
@@ -718,7 +718,7 @@ document.addEventListener('DOMContentLoaded', () => {
             searchResultsList.innerHTML = '';
             searchResultsContainer.style.display = 'block';
         }
-    });
+    }); // End of renderSearchResults function
 
 
     const createNewNoteButton = document.getElementById('create-new-note-button');


### PR DESCRIPTION
Resolved a syntax error in frontend/script.js caused by a missing closing parenthesis for the `searchInput.addEventListener` method call.

Additionally, a misplaced comment for the `renderSearchResults` function was moved to its correct location for better code clarity.