### PR TITLE
Fix: Resolve 'Unexpected token catch' in frontend/script.js

### DIFF
--- a/frontend/script.js
+++ b/frontend/script.js
@@ -712,13 +712,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 });
             }
             searchResultsContainer.style.display = 'block';
-        } catch (error) {
-            console.error("Error during search:", error);
-            searchResultsStatus.textContent = "Error during search.";
-            searchResultsList.innerHTML = '';
-            searchResultsContainer.style.display = 'block';
         }
-    }); // End of renderSearchResults function
+    } // End of renderSearchResults function
 
 
     const createNewNoteButton = document.getElementById('create-new-note-button');


### PR DESCRIPTION
Removes an orphaned catch block and corrects the function closing syntax for `renderSearchResults` function. This was causing a JavaScript syntax error around line 715.